### PR TITLE
docs: Update documentation to be consistent

### DIFF
--- a/doc/C/parted.8
+++ b/doc/C/parted.8
@@ -1,4 +1,4 @@
-.TH PARTED 8 "2007 March 29" parted "GNU Parted Manual"
+.TH PARTED 8 "2021 September 28" parted "GNU Parted Manual"
 .SH NAME
 parted \- a partition manipulation program
 .SH SYNOPSIS
@@ -24,7 +24,7 @@ lists partition layout on all block devices
 .B -m, --machine
 displays machine parseable output
 .TP
-.B -m, --json
+.B -j, --json
 displays JSON output
 .TP
 .B -s, --script
@@ -92,8 +92,9 @@ PC98, and GPT disklabels. The name can be placed in double quotes, if necessary.
 And depending on the shell may need to also be wrapped in single quotes so that
 the shell doesn't strip off the double quotes.
 .TP
-.B print
+.B print \fIprint-type\fP
 Display the partition table.
+\fIprint-type\fP is optional, and can be one of devices, free, list, or all.
 .TP
 .B quit
 Exit from \fBparted\fP.
@@ -131,6 +132,15 @@ human-friendly form for output).
 .TP
 .B toggle \fIpartition\fP \fIflag\fP
 Toggle the state of \fIflag\fP on \fIpartition\fP.
+.TP
+.B disk_set \fIflag\fP \fIstate\fP
+Change a \fIflag\fP on the disk to \fIstate\fP. A flag can be either "on" or "off".
+Some or all of these flags will be available, depending on what disk label you
+are using.  Supported flags are: "pmbr_boot" on GPT to enable the boot flag on the
+GPT's protective MBR partition.
+.TP
+.B disk_toggle \fIflag\fP
+Toggle the state of the disk \fIflag\fP.
 .TP
 .B version
 Display version information and a copyright message.

--- a/doc/parted.texi
+++ b/doc/parted.texi
@@ -14,7 +14,7 @@ and manipulating partition tables.
 @ifnottex @c texi2pdf don't understand copying and insertcopying ???
 @c modifications must also be done in the titlepage
 @copying
-Copyright @copyright{} 1999--2014, 2019--2021 Free Software Foundation, Inc.
+Copyright @copyright{} 1999--2021 Free Software Foundation, Inc.
 
 Permission is granted to copy, distribute and/or modify this document
 under the terms of the GNU Free Documentation License, Version 1.3 or
@@ -46,7 +46,7 @@ Free Documentation License''.
 @c @vskip 0pt plus 1filll
 
 @c modifications must also be done in the copying block
-Copyright @copyright{} 1999-2011 Free Software Foundation, Inc.
+Copyright @copyright{} 1999-2021 Free Software Foundation, Inc.
 
 Permission is granted to copy, distribute and/or modify this document
 under the terms of the GNU Free Documentation License, Version 1.3 or
@@ -117,9 +117,9 @@ power failure) and performs many safety checks.  However, there could
 be bugs in GNU Parted, so you should back up your important files before
 running Parted.
 
-The GNU Parted homepage is @uref{http://www.gnu.org/software/parted}.  The
+The GNU Parted homepage is @uref{https://www.gnu.org/software/parted}.  The
 library and frontend themselves can be downloaded from
-@uref{ftp://ftp.gnu.org/gnu/parted}.
+@uref{https://ftp.gnu.org/gnu/parted}.
 You can also find a listing of mailing lists, notes for contributing and
 more useful information on the web site.
 
@@ -129,7 +129,7 @@ Please include the output from these commands (for disk @file{/dev/hda}):
 
 @example
 @group
-# @kbd{parted /dev/hda print unit s print unit chs print}
+# @kbd{parted /dev/hda unit s print free}
 @end group
 @end example
 
@@ -157,6 +157,14 @@ installed:
 
 @itemize @bullet
 
+@item GNU parted source is available either as a source tarball:
+
+	@uref{https://git.savannah.gnu.org/gitweb/?p=parted.git}
+
+or using git (See the README-hacking instructions):
+
+	@uref{https://git.savannah.gnu.org/gitweb/?p=parted.git}
+
 @item libuuid, part of the e2fsprogs package.  If you don't have this,
 you can get it from:
 
@@ -167,7 +175,7 @@ If you want to compile Parted and e2fsprogs, note that you will need to
 
 @item GNU Readline (optional), available from
 
-	@uref{ftp://ftp.gnu.org/gnu/readline}
+	@uref{https://ftp.gnu.org/gnu/readline}
 
 If you are compiling Parted, and you don't have readline, you can
 disable Parted's readline support with the @kbd{--disable-readline}
@@ -176,7 +184,7 @@ option for @command{configure}.
 @item GNU gettext (or compatible software) for compilation, if
 internationalisation support is desired.
 
-	@uref{ftp://ftp.gnu.org/gnu/gettext}
+	@uref{https://ftp.gnu.org/gnu/gettext}
 
 @end itemize
 
@@ -259,7 +267,7 @@ disable writing (for debugging)
 @subsection Introduction
 If you want to run GNU Parted on a machine without GNU/Linux installed,
 or you want to modify a root or boot partition, use GParted Live:
-@uref{http://gparted.sourceforge.net/livecd.php}.
+@uref{https://gparted.org/livecd.php}.
 
 @node    Using Parted
 @chapter Using Parted
@@ -402,6 +410,10 @@ Options:
 @itemx --help
 display a help message
 
+@item -l
+@itemx --list
+lists partition layout on all block devices
+
 @item -m
 @itemx --machine
 display output in machine parseable format
@@ -416,7 +428,7 @@ never prompt the user
 
 @item -f
 @itemx --fix
-automatically answer exceptions with "fix" in script mode, whcih is useful for:
+automatically answer exceptions with "fix" in script mode, which is useful for:
 GPT header not including full disk size; moving the backup GPT table to the end of the disk;
 MAC fix missing partition map entry; etc.
 
@@ -441,6 +453,7 @@ GNU Parted provides the following commands:
 @menu
 * align-check::
 * disk_set::
+* disk_toggle::
 * help::
 * mklabel::
 * mkpart::
@@ -452,6 +465,7 @@ GNU Parted provides the following commands:
 * rm::
 * select::
 * set::
+* toggle::
 * unit::
 @end menu
 
@@ -515,6 +529,16 @@ in machine mode.
 Set the PMBR's boot flag.
 @end deffn
 
+@node disk_toggle
+@subsection disk_toggle
+@cindex disk_toggle, command description
+@cindex command description, disk_toggle
+
+@deffn Command disk_toggle @var{flag}
+
+Toggle the state of the disk flag.
+@end deffn
+
 @node help
 @subsection help
 @cindex help, command description
@@ -551,9 +575,12 @@ thing: partition table, partition map.}
 
 @var{label-type} must be one of these supported disk labels:
 @itemize @bullet
+@item aix
+@item amiga
 @item bsd
-@item loop (raw disk access)
+@item dvh
 @item gpt
+@item loop (raw disk access)
 @item mac
 @item msdos
 @item pc98
@@ -594,14 +621,19 @@ partition table.
 
 @var{fs-type} must be one of these supported file systems:
 @itemize @bullet
-@item ext2
+@item btrfs
+@item ext2, ext3, ext4
 @item fat16, fat32
 @item hfs, hfs+, hfsx
-@item linux-swap
-@item NTFS
+@item hp-ufs
+@item jfs
+@item linux-swap, linux-swap(new,old,v0,v1)
+@item nilfs2
+@item ntfs
 @item reiserfs
+@item sun-ufs
 @item ufs
-@item btrfs
+@item xfs
 @end itemize
 
 For example, the following creates a logical partition that will contain
@@ -671,29 +703,56 @@ Set the name of partition 2 to `Secret Documents'.
 @cindex print, command description
 @cindex command description, print
 
-@deffn Command print [@var{number}]
+@deffn Command print [@var{print-type}]
 
 Displays the partition table on the device parted is editing, or
 detailed information about a particular partition.
+
+@var{print-type} is optional, and can be one of @samp{devices},
+@samp{free}, @samp{list}, or @samp{all}.
+
+@table @code
+
+@item devices
+display all active block devices
+
+@item free
+display information about free unpartitioned space on the current block device
+
+@item list, all
+display the partition tables of all active block devices
+
+@end table
 
 Example:
 
 @example
 @group
 (parted) @kbd{print}
-Disk geometry for /dev/hda: 0.000-2445.679 megabytes
-Disk label type: msdos
-Minor    Start       End     Type      Filesystem  Flags
-1          0.031    945.000  primary   fat32       boot, lba
-2        945.000   2358.562  primary   ext2
-3       2358.562   2445.187  primary   linux-swap
-(parted) @kbd{print 1}
-Minor: 1
-Flags: boot, lba
-File System: fat32
-Size:            945.000Mb (0%)
-Minimum size:     84.361Mb (0%)
-Maximum size:   2445.679Mb (100%)
+Model: ATA Samsung SSD 850 (scsi)
+Disk /dev/sda: 2684MB
+Sector size (logical/physical): 512B/512B
+Partition Table: msdos
+Disk Flags:
+
+Number  Start   End     Size    Type     File system     Flags
+ 1      1049kB  1000MB  999MB   primary                  boot, lba
+ 2      1000MB  2300MB  1299MB  primary  ext2            lba
+ 3      2300MB  2500MB  200MB   primary  linux-swap(v1)  lba
+(parted) @kbd{print free}
+Model: ATA Samsung SSD 850 (scsi)
+Disk /dev/sda: 2684MB
+Sector size (logical/physical): 512B/512B
+Partition Table: msdos
+Disk Flags:
+
+Number  Start   End     Size    Type     File system     Flags
+        16.4kB  1049kB  1032kB           Free Space
+ 1      1049kB  1000MB  999MB   primary                  boot, lba
+ 2      1000MB  2300MB  1299MB  primary  ext2            lba
+ 3      2300MB  2500MB  200MB   primary  linux-swap(v1)  lba
+        2500MB  2684MB  185MB            Free Space
+
 @end group
 @end example
 @end deffn
@@ -728,43 +787,58 @@ may delay this.
 Rescue a lost partition that used to be located approximately between
 @var{start} and @var{end}.  If such a partition is found, Parted will
 ask you if you want to create a partition for it.  This is useful if you
-accidently deleted a partition with parted's rm command, for example.
+accidentally deleted a partition with parted's rm command, for example.
 
 Example:
 
 @example
 (parted) @kbd{print}
 @group
-Disk geometry for /dev/hdc: 0.000-8063.507 megabytes
-Disk label type: msdos
-Minor    Start       End     Type      Filesystem  Flags
-1          0.031   8056.032  primary   ext3
+Model: ATA Samsung SSD 850 (scsi)
+Disk /dev/sda: 2684MB
+Sector size (logical/physical): 512B/512B
+Partition Table: msdos
+Disk Flags:
+
+Number  Start   End     Size    Type     File system     Flags
+ 1      1049kB  1000MB  999MB   primary                  boot, lba
+ 2      1000MB  2300MB  1299MB  primary  ext4            lba
 @end group
 (parted) @kbd{rm}
-Partition number? 1
+Partition number? 2
 (parted) @kbd{print}
 @group
-Disk geometry for /dev/hdc: 0.000-8063.507 megabytes
-Disk label type: msdos
-Minor    Start       End     Type      Filesystem  Flags
+Model: ATA Samsung SSD 850 (scsi)
+Disk /dev/sda: 2684MB
+Sector size (logical/physical): 512B/512B
+Partition Table: msdos
+Disk Flags:
+
+Number  Start   End     Size    Type     File system     Flags
+ 1      1049kB  1000MB  999MB   primary                  boot, lba
 @end group
 @end example
 
-OUCH!  We deleted our ext3 partition!!!  Parted comes to the rescue...
+OUCH!  We deleted our ext4 partition!!!  Parted comes to the rescue...
 
 @example
 (parted) @kbd{rescue}
-Start? 0
-End? 8056
-Information: A ext3 primary partition was found at 0.031MB ->
-8056.030MB.  Do you want to add it to the partition table?
+Start? 1000
+End? 2684
+Information: A ext4 primary partition was found at 1000MB ->
+2300MB.  Do you want to add it to the partition table?
 Yes/No/Cancel? @kbd{y}
 (parted) @kbd{print}
 @group
-Disk geometry for /dev/hdc: 0.000-8063.507 megabytes
-Disk label type: msdos
-Minor    Start       End     Type      Filesystem  Flags
-1          0.031   8056.032  primary   ext3
+Model: ATA Samsung SSD 850 (scsi)
+Disk /dev/sda: 2684MB
+Sector size (logical/physical): 512B/512B
+Partition Table: msdos
+Disk Flags:
+
+Number  Start   End     Size    Type     File system     Flags
+ 1      1049kB  1000MB  999MB   primary                  boot, lba
+ 2      1000MB  2300MB  1299MB  primary  ext4            lba
 @end group
 @end example
 
@@ -795,7 +869,7 @@ but when shrinking, you need to shrink the filesystem before the partition.
 
 @deffn Command rm @var{number}
 
-Removes the partition with number @var{number}.  If you accidently delete
+Removes the partition with number @var{number}.  If you accidentally delete
 a partition with this command, use mkpart to
 recover it.  Also, you can use the gpart program (@pxref{Related information})
 to recover damaged disk labels.
@@ -824,8 +898,8 @@ Remove partition 3.
 @deffn Command select @var{device}
 
 Selects the device, @var{device}, for Parted to edit.  The device can
-be a Linux hard disk device, a partition, a software RAID device or
-LVM logical volume.
+be a Linux hard disk device, a partition, a software RAID device,
+LVM logical volume, or disk image file.
 
 Example:
 
@@ -943,6 +1017,17 @@ Example:
 @end example
 
 Set the @samp{boot} flag on partition 1.
+@end deffn
+
+@node toggle
+@subsection toggle
+@cindex toggle, command description
+@cindex command description, toggle
+
+@deffn Command toggle @var{number} @var{flag}
+
+Toggle the state of @var{flag} on partition @var{number}.
+
 @end deffn
 
 @node unit
@@ -1117,7 +1202,7 @@ software
 
 This manual was based on the file @kbd{USER} included in GNU Parted version
 1.4.22 source distribution.  The GNU Parted source distribution is
-available at @uref{ftp.gnu.org/gnu/parted}.
+available at @uref{https://ftp.gnu.org/gnu/parted}.
 
 Initial Texinfo formatting by Richard M. Kreuter, 2002.
 

--- a/parted/parted.c
+++ b/parted/parted.c
@@ -2222,7 +2222,7 @@ command_register (commands, command_create (
         str_list_create_unique ("print", _("print"), NULL),
         do_print,
         str_list_create (
-_("print [devices|free|list,all|NUMBER]     display the partition table, "
+_("print [devices|free|list,all]            display the partition table, "
   "available devices, free space, all found partitions, or a particular "
   "partition"),
 NULL),
@@ -2233,8 +2233,6 @@ _("  devices   : display all active block devices\n"),
 _("  free      : display information about free unpartitioned space on the "
   "current block device\n"),
 _("  list, all : display the partition tables of all active block devices\n"),
-_("  NUMBER    : display more detailed information about this particular "
-  "partition\n"),
 NULL), 1));
 
 command_register (commands, command_create (


### PR DESCRIPTION
This fixes some missing commands in the parted.texi file used to
generate the web manual and info document. It also removes documentation
for the never-implemented 'print NUMBER' command which only returns 1.

The parted manpage has been updated to document the available print
options, disk_set, and disk_toggle commands.