### PR TITLE
parted: Add display of GPT UUIDs in JSON output

### DIFF
--- a/include/parted/disk.in.h
+++ b/include/parted/disk.in.h
@@ -98,10 +98,12 @@ enum _PedDiskTypeFeature {
         PED_DISK_TYPE_PARTITION_NAME=2,       /**< supports partition names */
         PED_DISK_TYPE_PARTITION_TYPE_ID=4,    /**< supports partition type-ids */
         PED_DISK_TYPE_PARTITION_TYPE_UUID=8,  /**< supports partition type-uuids */
+        PED_DISK_TYPE_DISK_UUID=16,           /**< supports disk uuids */
+        PED_DISK_TYPE_PARTITION_UUID=32,      /**< supports partition uuids */
 };
 // NOTE: DO NOT define using enums
-#define PED_DISK_TYPE_FIRST_FEATURE    1 // PED_DISK_TYPE_EXTENDED
-#define PED_DISK_TYPE_LAST_FEATURE     8 // PED_DISK_TYPE_PARTITION_TYPE_UUID
+#define PED_DISK_TYPE_FIRST_FEATURE    1  // PED_DISK_TYPE_EXTENDED
+#define PED_DISK_TYPE_LAST_FEATURE     32 // PED_DISK_TYPE_PARTITION_UUID
 
 struct _PedDisk;
 struct _PedPartition;
@@ -228,6 +230,7 @@ struct _PedDiskOps {
         int (*disk_is_flag_available) (
                 const PedDisk *disk,
                 PedDiskFlag flag);
+        uint8_t* (*disk_get_uuid) (const PedDisk* disk);
         /** \todo add label guessing op here */
 
         /* partition operations */
@@ -259,6 +262,8 @@ struct _PedDiskOps {
 
         int (*partition_set_type_uuid) (PedPartition* part, const uint8_t* uuid);
         uint8_t* (*partition_get_type_uuid) (const PedPartition* part);
+
+        uint8_t* (*partition_get_uuid) (const PedPartition* part);
 
         int (*partition_align) (PedPartition* part,
                                 const PedConstraint* constraint);
@@ -331,6 +336,8 @@ extern int ped_disk_set_flag(PedDisk *disk, PedDiskFlag flag, int state);
 extern int ped_disk_get_flag(const PedDisk *disk, PedDiskFlag flag);
 extern int ped_disk_is_flag_available(const PedDisk *disk, PedDiskFlag flag);
 
+extern uint8_t* ped_disk_get_uuid (const PedDisk* disk);
+
 extern const char *ped_disk_flag_get_name(PedDiskFlag flag);
 extern PedDiskFlag ped_disk_flag_get_by_name(const char *name);
 extern PedDiskFlag ped_disk_flag_next(PedDiskFlag flag) _GL_ATTRIBUTE_CONST;
@@ -366,6 +373,8 @@ extern uint8_t ped_partition_get_type_id (const PedPartition* part);
 
 extern int ped_partition_set_type_uuid (PedPartition* part, const uint8_t* uuid);
 extern uint8_t* ped_partition_get_type_uuid (const PedPartition* part);
+
+extern uint8_t* ped_partition_get_uuid (const PedPartition* part);
 
 extern int ped_partition_is_busy (const PedPartition* part);
 extern char* ped_partition_get_path (const PedPartition* part);

--- a/parted/parted.c
+++ b/parted/parted.c
@@ -1215,6 +1215,14 @@ _print_disk_info (const PedDevice *dev, const PedDisk *diskp)
             ul_jsonwrt_value_u64 (&json, "physical-sector-size", dev->phys_sector_size);
             ul_jsonwrt_value_s (&json, "label", pt_name);
             if (diskp) {
+                bool has_disk_uuid = ped_disk_type_check_feature (diskp->type, PED_DISK_TYPE_DISK_UUID);
+                if (has_disk_uuid) {
+                    uint8_t* uuid = ped_disk_get_uuid (diskp);
+                    static char buf[UUID_STR_LEN];
+                    uuid_unparse_lower (uuid, buf);
+                    ul_jsonwrt_value_s (&json, "uuid", buf);
+                    free (uuid);
+                }
                 ul_jsonwrt_value_u64 (&json, "max-partitions",
                                       ped_disk_get_max_primary_partition_count(diskp));
                 disk_print_flags_json (diskp);
@@ -1360,6 +1368,8 @@ do_print (PedDevice** dev, PedDisk** diskp)
 							PED_DISK_TYPE_PARTITION_TYPE_ID);
         bool has_type_uuid = ped_disk_type_check_feature ((*diskp)->type,
 							  PED_DISK_TYPE_PARTITION_TYPE_UUID);
+        bool has_part_uuid = ped_disk_type_check_feature ((*diskp)->type,
+							  PED_DISK_TYPE_PARTITION_UUID);
 
         PedPartition* part;
         if (opt_output_mode == HUMAN) {
@@ -1510,6 +1520,14 @@ do_print (PedDevice** dev, PedDisk** diskp)
                         uuid_unparse_lower (type_uuid, buf);
                         ul_jsonwrt_value_s (&json, "type-uuid", buf);
                         free (type_uuid);
+                    }
+
+                    if (has_part_uuid) {
+                        uint8_t* uuid = ped_partition_get_uuid (part);
+                        static char buf[UUID_STR_LEN];
+                        uuid_unparse_lower (uuid, buf);
+                        ul_jsonwrt_value_s (&json, "uuid", buf);
+                        free (uuid);
                     }
 
                     if (has_name) {

--- a/tests/t0800-json-gpt.sh
+++ b/tests/t0800-json-gpt.sh
@@ -32,8 +32,8 @@ parted --script "$dev" mkpart "test1" ext4 10% 20% > out 2>&1 || fail=1
 parted --script "$dev" mkpart "test2" xfs 20% 60% > out 2>&1 || fail=1
 parted --script "$dev" set 2 raid on > out 2>&1 || fail=1
 
-# print with json format
-parted --script --json "$dev" unit s print free > out 2>&1 || fail=1
+# print with json format, replace non-deterministic uuids
+parted --script --json "$dev" unit s print free | sed -E 's/"uuid": "[0-9a-f-]{36}"/"uuid": "<uuid>"/' > out 2>&1 || fail=1
 
 cat <<EOF > exp || fail=1
 {
@@ -45,6 +45,7 @@ cat <<EOF > exp || fail=1
       "logical-sector-size": 512,
       "physical-sector-size": 512,
       "label": "gpt",
+      "uuid": "<uuid>",
       "max-partitions": 128,
       "flags": [
           "pmbr_boot"
@@ -63,6 +64,7 @@ cat <<EOF > exp || fail=1
             "size": "10240s",
             "type": "primary",
             "type-uuid": "0fc63daf-8483-4772-8e79-3d69d8477de4",
+            "uuid": "<uuid>",
             "name": "test1"
          },{
             "number": 2,
@@ -71,6 +73,7 @@ cat <<EOF > exp || fail=1
             "size": "40960s",
             "type": "primary",
             "type-uuid": "a19d880f-05fc-4d3b-a006-743f0f84911e",
+            "uuid": "<uuid>",
             "name": "test2",
             "flags": [
                 "raid"

--- a/tests/t0900-type-gpt.sh
+++ b/tests/t0900-type-gpt.sh
@@ -32,8 +32,8 @@ parted --script "$dev" mkpart "''" "linux-swap" 10% 20% > out 2>&1 || fail=1
 # set type-uuid
 parted --script "$dev" type 1 "deadfd6d-a4ab-43c4-84e5-0933c84b4f4f" || fail=1
 
-# print with json format
-parted --script --json "$dev" unit s print > out 2>&1 || fail=1
+# print with json format, replace non-deterministic uuids
+parted --script --json "$dev" unit s print | sed -E 's/"uuid": "[0-9a-f-]{36}"/"uuid": "<uuid>"/' > out 2>&1 || fail=1
 
 cat <<EOF > exp || fail=1
 {
@@ -45,6 +45,7 @@ cat <<EOF > exp || fail=1
       "logical-sector-size": 512,
       "physical-sector-size": 512,
       "label": "gpt",
+      "uuid": "<uuid>",
       "max-partitions": 128,
       "partitions": [
          {
@@ -53,7 +54,8 @@ cat <<EOF > exp || fail=1
             "end": "20479s",
             "size": "10240s",
             "type": "primary",
-            "type-uuid": "deadfd6d-a4ab-43c4-84e5-0933c84b4f4f"
+            "type-uuid": "deadfd6d-a4ab-43c4-84e5-0933c84b4f4f",
+            "uuid": "<uuid>"
          }
       ]
    }


### PR DESCRIPTION
This adds 2 new disk type features, one for the whole disk UUID and another for the per-partition UUID. It adds ped_disk_get_uuid and ped_partition_get_uuid functions to retrieve them.

It adds them to the JSON output on GPT disklabeled disks as "uuid" in the disk and partitions sections of the JSON output.

Signed-off-by: Brian C. Lane <bcl@redhat.com>