### PR TITLE
Add a --readonly flag

### DIFF
--- a/libparted/arch/beos.c
+++ b/libparted/arch/beos.c
@@ -335,7 +335,7 @@ beos_open (PedDevice* dev)
 	BEOSSpecific* arch_specific = BEOS_SPECIFIC(dev);
 
 retry:
-	arch_specific->fd = open(dev->path, O_RDWR);
+	arch_specific->fd = open(dev->path, dev->read_only ? RD_MODE : RW_MODE);
 	if (arch_specific->fd == -1) {
 		char* rw_error_msg = strerror(errno);
 

--- a/libparted/arch/beos.c
+++ b/libparted/arch/beos.c
@@ -360,8 +360,6 @@ retry:
 				dev->path, rw_error_msg, dev->path);
 			dev->read_only = 1;
 		}
-	} else {
-		dev->read_only = 0;
 	}
 
 	_flush_cache (dev);

--- a/libparted/arch/gnu.c
+++ b/libparted/arch/gnu.c
@@ -361,8 +361,6 @@ gnu_new (const char* path)
 				dev->path, strerror (rw_err), dev->path);
 			dev->read_only = 1;
 		}
-	} else {
-		dev->read_only = 0;
 	}
 
 	_flush_cache (dev);

--- a/libparted/arch/linux.c
+++ b/libparted/arch/linux.c
@@ -1709,7 +1709,7 @@ _device_open_ro (PedDevice* dev)
 static int
 linux_open (PedDevice* dev)
 {
-    return _device_open (dev, RW_MODE);
+    return _device_open (dev, dev->read_only ? RD_MODE : RW_MODE);
 }
 
 static int

--- a/libparted/arch/linux.c
+++ b/libparted/arch/linux.c
@@ -1745,8 +1745,6 @@ retry:
                                 dev->path, rw_error_msg, dev->path);
                         dev->read_only = 1;
                 }
-        } else {
-                dev->read_only = 0;
         }
 
         _flush_cache (dev);

--- a/libparted/tests/Makefile.am
+++ b/libparted/tests/Makefile.am
@@ -3,10 +3,11 @@
 #
 # This file may be modified and/or distributed without restriction.
 
-TESTS = t1000-label.sh t1001-flags.sh t2000-disk.sh t2100-zerolen.sh \
+TESTS = t1000-label.sh t1001-flags.sh t1002-read_only.sh \
+	t2000-disk.sh t2100-zerolen.sh \
 	t3000-symlink.sh t4000-volser.sh
 EXTRA_DIST = $(TESTS)
-check_PROGRAMS = label disk zerolen symlink volser flags
+check_PROGRAMS = label disk zerolen symlink volser flags read_only
 AM_CFLAGS = $(WARN_CFLAGS) $(WERROR_CFLAGS)
 
 LDADD = \
@@ -26,6 +27,7 @@ zerolen_SOURCES = common.h common.c zerolen.c
 symlink_SOURCES = common.h common.c symlink.c
 volser_SOURCES = common.h common.c volser.c
 flags_SOURCES = common.h common.c flags.c
+read_only_SOURCES = common.h common.c read_only.c
 
 # Arrange to symlink to tests/init.sh.
 CLEANFILES = init.sh

--- a/libparted/tests/read_only.c
+++ b/libparted/tests/read_only.c
@@ -1,0 +1,133 @@
+#include <config.h>
+#include <unistd.h>
+
+#include <check.h>
+
+#include <parted/parted.h>
+
+#include "common.h"
+#include "progname.h"
+
+#define STREQ(a, b) (strcmp (a, b) == 0)
+
+static char* temporary_disk;
+
+static void
+create_disk (void)
+{
+        temporary_disk = _create_disk (80 * 1024 * 1024);
+        ck_assert_msg(temporary_disk != NULL, "Failed to create temporary disk");
+}
+
+static void
+destroy_disk (void)
+{
+        unlink (temporary_disk);
+        free (temporary_disk);
+}
+
+/* TEST: Test reading gpt disk partitin in read_only mode */
+START_TEST (test_read_only_gpt)
+{
+        PedDevice* dev = ped_device_get (temporary_disk);
+        if (dev == NULL)
+                return;
+
+        PedDisk* disk = ped_disk_new_fresh (dev, ped_disk_type_get ("gpt"));
+        PedConstraint *constraint = ped_constraint_any (dev);
+        PedPartition *part = ped_partition_new (disk, PED_PARTITION_NORMAL,
+            ped_file_system_type_get("ext4"), 2048, 4096);
+        ped_partition_set_name(part, "read-only-test");
+        ped_disk_add_partition (disk, part, constraint);
+        ped_disk_commit (disk);
+        ped_constraint_destroy (constraint);
+
+        ped_disk_destroy (disk);
+        ped_device_destroy (dev);
+
+        // Now open it with read only mode
+        dev = ped_device_get (temporary_disk);
+        if (dev == NULL)
+                return;
+
+        dev->read_only = 1;
+        disk = ped_disk_new(dev);
+        ck_assert_ptr_nonnull(disk);
+        part = ped_disk_get_partition(disk, 1);
+        ck_assert_ptr_nonnull(disk);
+        ck_assert_str_eq(ped_partition_get_name(part), "read-only-test");
+        ck_assert_int_eq(part->geom.start, 2048);
+        ck_assert_int_eq(part->geom.length, 2049);
+        ck_assert_int_eq(part->geom.end, 4096);
+        ped_disk_destroy (disk);
+        ped_device_destroy (dev);
+}
+END_TEST
+
+/* TEST: Test reading msdos disk partitin in read_only mode */
+START_TEST (test_read_only_msdos)
+{
+        PedDevice* dev = ped_device_get (temporary_disk);
+        if (dev == NULL)
+                return;
+
+        PedDisk* disk = ped_disk_new_fresh (dev, ped_disk_type_get ("msdos"));
+        PedConstraint *constraint = ped_constraint_any (dev);
+        PedPartition *part = ped_partition_new (disk, PED_PARTITION_NORMAL,
+            ped_file_system_type_get("ext4"), 2048, 4096);
+        ped_disk_add_partition (disk, part, constraint);
+        ped_disk_commit (disk);
+        ped_constraint_destroy (constraint);
+        ped_disk_destroy (disk);
+        ped_device_destroy (dev);
+
+        // Now open it with read only mode
+        dev = ped_device_get (temporary_disk);
+        if (dev == NULL)
+                return;
+
+        dev->read_only = 1;
+        disk = ped_disk_new(dev);
+        ck_assert_ptr_nonnull(disk);
+        part = ped_disk_get_partition(disk, 1);
+        ck_assert_ptr_nonnull(disk);
+        ck_assert_int_eq(part->geom.start, 2048);
+        ck_assert_int_eq(part->geom.length, 2049);
+        ck_assert_int_eq(part->geom.end, 4096);
+        ped_disk_destroy (disk);
+        ped_device_destroy (dev);
+}
+END_TEST
+
+int
+main (int argc, char **argv)
+{
+        set_program_name (argv[0]);
+        int number_failed;
+        Suite* suite = suite_create ("Partition Flags");
+        TCase* tcase_gpt = tcase_create ("GPT");
+        TCase* tcase_msdos = tcase_create ("MSDOS");
+
+        /* Fail when an exception is raised */
+        ped_exception_set_handler (_test_exception_handler);
+
+        tcase_add_checked_fixture (tcase_gpt, create_disk, destroy_disk);
+        tcase_add_test (tcase_gpt, test_read_only_gpt);
+        /* Disable timeout for this test */
+        tcase_set_timeout (tcase_gpt, 0);
+        suite_add_tcase (suite, tcase_gpt);
+
+        tcase_add_checked_fixture (tcase_msdos, create_disk, destroy_disk);
+        tcase_add_test (tcase_msdos, test_read_only_msdos);
+        /* Disable timeout for this test */
+        tcase_set_timeout (tcase_msdos, 0);
+        suite_add_tcase (suite, tcase_msdos);
+
+        SRunner* srunner = srunner_create (suite);
+        srunner_run_all (srunner, CK_VERBOSE);
+
+        number_failed = srunner_ntests_failed (srunner);
+        srunner_free (srunner);
+
+        return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}

--- a/libparted/tests/t1002-read_only.sh
+++ b/libparted/tests/t1002-read_only.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# run the flags unittest
+
+# Copyright (C) 2007-2014, 2019-2022 Free Software Foundation, Inc.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+. "${top_srcdir=../..}/tests/init.sh"; path_prepend_ .
+
+read_only || fail=1
+
+Exit $fail

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -8,6 +8,7 @@ TESTS = \
   t0010-script-no-ctrl-chars.sh \
   t0100-print.sh \
   t0101-print-empty.sh \
+  t0102-print-readonly.sh \
   t0200-gpt.sh \
   t0201-gpt.sh \
   t0202-gpt-pmbr.sh \
@@ -48,6 +49,7 @@ TESTS = \
   t1101-busy-partition.sh \
   t1102-loop-label.sh \
   t1104-remove-and-add-partition.sh \
+  t1105-mklabel-readonly.sh \
   t1700-probe-fs.sh \
   t1701-rescue-fs.sh \
   t2200-dos-label-recog.sh \

--- a/tests/t0102-print-readonly.sh
+++ b/tests/t0102-print-readonly.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Test printing the partition table in readonly mode
+
+# Copyright (C) 2023 Free Software Foundation, Inc.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+. "${srcdir=.}/init.sh"; path_prepend_ ../parted
+
+dev=loop-file
+
+# create device
+truncate --size 10MiB "$dev" || fail=1
+
+parted --script "$dev" mklabel msdos > out 2>&1 || fail=1
+parted --script "$dev" mkpart primary ext4 64s 128s > out 2>&1 || fail=1
+parted --readonly --script "$dev" u s p free > out 2>&1 || fail=1
+
+Exit $fail

--- a/tests/t1105-mklabel-readonly.sh
+++ b/tests/t1105-mklabel-readonly.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Test printing the partition table in readonly mode
+
+# Copyright (C) 2023 Free Software Foundation, Inc.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+. "${srcdir=.}/init.sh"; path_prepend_ ../parted
+
+dev=loop-file
+
+# create device
+truncate --size 10MiB "$dev" || fail=1
+
+parted --readonly --script "$dev" mklabel msdos > out 2>&1; test $? = 1 || fail=1
+
+# create expected output file
+echo "Error: Can't write to $PWD/$dev, because it is opened read-only." > exp
+compare exp out || fail=1
+
+
+Exit $fail


### PR DESCRIPTION
This opens the device in readonly mode, preventing any udev events when reading the device. Any attempts to write to it will result in a write error.
